### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,26 +6,26 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Button     KEYWORD1
-Led        KEYWORD1
-Buzzer     KEYWORD1
-Ultrasonic KEYWORD1
+Button	KEYWORD1
+Led	KEYWORD1
+Buzzer	KEYWORD1
+Ultrasonic	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-pin      KEYWORD2
-state    KEYWORD2
-on       KEYWORD2
-off      KEYWORD2
-buzz     KEYWORD2
-stopBuzz KEYWORD2
-playTone KEYWORD2
-stopTone KEYWORD2
-trigger  KEYWORD2
-echoTime KEYWORD2
-distance KEYWORD2
+pin	KEYWORD2
+state	KEYWORD2
+on	KEYWORD2
+off	KEYWORD2
+buzz	KEYWORD2
+stopBuzz	KEYWORD2
+playTone	KEYWORD2
+stopTone	KEYWORD2
+trigger	KEYWORD2
+echoTime	KEYWORD2
+distance	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords